### PR TITLE
feat(azure_linux_virtual_machine): VM output for SSH user (testing)

### DIFF
--- a/azure_linux_virtual_machine/README.md
+++ b/azure_linux_virtual_machine/README.md
@@ -155,5 +155,6 @@ No modules.
 |------|-------------|
 | <a name="output_id"></a> [id](#output\_id) | ID of the managed resource |
 | <a name="output_private_ip_address"></a> [private\_ip\_address](#output\_private\_ip\_address) | Primary private ip address |
-| <a name="output_ssh_private_key_pem"></a> [ssh\_private\_key\_pem](#output\_ssh\_private\_key\_pem) | Exported for emergency cases, but Entra ID authentication should be used |
+| <a name="output_ssh_private_key_pem"></a> [ssh\_private\_key\_pem](#output\_ssh\_private\_key\_pem) | Exported for emergency/testing cases, but Entra ID authentication should be used |
+| <a name="output_ssh_username"></a> [ssh\_username](#output\_ssh\_username) | Exported for emergency/testing cases, but Entra ID authentication should be used |
 <!-- END_TF_DOCS -->

--- a/azure_linux_virtual_machine/outputs.tf
+++ b/azure_linux_virtual_machine/outputs.tf
@@ -10,6 +10,11 @@ output "private_ip_address" {
 
 output "ssh_private_key_pem" {
   value       = tls_private_key.ssh.private_key_pem
-  description = "Exported for emergency cases, but Entra ID authentication should be used"
+  description = "Exported for emergency/testing cases, but Entra ID authentication should be used"
   sensitive   = true
+}
+
+output "ssh_username" {
+  value       = tolist(azurerm_linux_virtual_machine.this.admin_ssh_key[*].username)[0]
+  description = "Exported for emergency/testing cases, but Entra ID authentication should be used"
 }


### PR DESCRIPTION
Add username of SSH admin as output, mainly for testing purposes: in fact, Entra ID authentication should be used instead of SSH key.