### PR TITLE
fix(azure_firewall): SKU tier of policy due to changed default in v4

### DIFF
--- a/azure_firewall/main.tf
+++ b/azure_firewall/main.tf
@@ -45,6 +45,7 @@ resource "azurerm_firewall_policy" "this" {
   name                = "${var.base_name}-afwp"
   resource_group_name = var.resource_group_name
   location            = var.location
+  sku                 = var.sku_tier
 
   tags = var.tags
 }


### PR DESCRIPTION
Using azurerm provider v4, the SKU of the policy defaults to Standard.