### PR TITLE
feat(azure_linux_virtual_machine_extensions): Optional DCE

### DIFF
--- a/azure_linux_virtual_machine_extensions/main.tf
+++ b/azure_linux_virtual_machine_extensions/main.tf
@@ -43,7 +43,7 @@ resource "azurerm_monitor_data_collection_rule_association" "dcr_association" {
 
 # associate the vm to a data collection endpoint
 resource "azurerm_monitor_data_collection_rule_association" "dce_association" {
-  count = var.azure_monitor_agent.enabled ? 1 : 0
+  count = var.azure_monitor_agent.enabled && var.azure_monitor_agent.data_collection_endpoint_id != null ? 1 : 0
 
   # it seems that the name must be precisely this one
   name                        = "configurationAccessEndpoint"

--- a/azure_linux_virtual_machine_extensions/variables.tf
+++ b/azure_linux_virtual_machine_extensions/variables.tf
@@ -48,11 +48,6 @@ variable "azure_monitor_agent" {
     condition     = !var.azure_monitor_agent.enabled || var.azure_monitor_agent.data_collection_rule_id != null
     error_message = "data_collection_rule_id is required when azure monitor agent is enabled"
   }
-
-  validation {
-    condition     = !var.azure_monitor_agent.enabled || var.azure_monitor_agent.data_collection_endpoint_id != null
-    error_message = "data_collection_endpoint_id is required when azure monitor agent is enabled"
-  }
 }
 
 


### PR DESCRIPTION
DCE (Data Collection Endpoint) is now optional when using Azure Monitor extension.

This is to reflect cases when we want to use just the start public
facing Monitor endpoints instead of using the Azure Monitor Private
Link infrastructure.