### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - "**.md"
       - ".**"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/ict-terraform-modules/security/code-scanning/3](https://github.com/pagopa/ict-terraform-modules/security/code-scanning/3)

In general, the fix is to declare explicit `permissions:` for the workflow or for the specific job, limiting the `GITHUB_TOKEN` to only the scopes needed. For a release workflow using `semantic-release`, the token must at least be able to read repository contents and write releases/tags. A safe, minimal, and common choice is to set `contents: write` at the workflow root so it applies to all jobs (we currently have just one job). If the workflow also needs to interact with other GitHub features (issues, PRs), additional scopes (like `issues: write`, `pull-requests: write`) can be added, but we will not introduce them unless clearly required by the shown snippet.

The single best fix here is to add a `permissions:` block near the top of `.github/workflows/release.yml`, at the workflow level, between the `on:` block and the `jobs:` block. This keeps existing behavior (semantic-release can still create tags and releases via `contents: write`) while documenting and constraining the token’s capabilities. No imports or other files are involved; the change is purely within this YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
