### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,5 +1,9 @@
 name: "Validate PR title"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/ict-terraform-modules/security/code-scanning/1](https://github.com/pagopa/ict-terraform-modules/security/code-scanning/1)

In general, the fix is to explicitly add a `permissions` section to the workflow (at the top level or per job) that grants only the minimal GitHub token scopes needed. For this PR title validation workflow, the action only needs to read pull request data and report a check conclusion; it does not need to push code or modify issues, so we can safely restrict repository contents to read-only and give write access only to pull-request–related scopes if required by the action.

The best, minimally invasive fix here is to add a `permissions` block at the workflow root (between `name` and `on`) so it applies to the `main` job. A reasonable least-privilege configuration is:

- `contents: read` to allow basic repository metadata access.
- `pull-requests: write` to allow the action to update the PR check status and potentially PR metadata (labels, etc.) if it uses that capability.

This preserves existing behavior (the action can still run and report status) while ensuring the GITHUB_TOKEN is not granted broad write access to repository contents or other resources. Concretely, in `.github/workflows/pr-title.yml`, insert a `permissions` mapping after line 1. No imports or additional definitions are needed, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
